### PR TITLE
Add reset-ownership script

### DIFF
--- a/bioc-run
+++ b/bioc-run
@@ -133,7 +133,16 @@ docker run --rm \
       $biocdocker \
       bash -c 'chown -R $USERID:1000 /home/rstudio /usr/local/lib/r/host-site-library'
 
-if [ "$envtype" == "rstudio" ]; then
+if [ "$envtype" == "reset-ownership" ]; then
+    docker run -e PASSWORD=$password \
+        -v $DOCKER_HOME:/home/rstudio \
+        -v $DOCKER_RPKGS:/usr/local/lib/r/host-site-library \
+        -e USERID=$(cat /etc/passwd | grep "^$(whoami):" | awk -F':' '{print $3}') \
+        -e GROUPID=$(cat /etc/passwd | grep "^$(whoami):" | awk -F':' '{print $4}') \
+        -u root \
+        $biocdocker \
+        bash -c 'chown -R $USERID:$GROUPID /home/rstudio /usr/local/lib/r/host-site-library'
+elif [ "$envtype" == "rstudio" ]; then
     echo "=================================================="
     echo "Open RStudio running Bioconductor version $version at http://localhost:$port"
     echo "Login with username: rstudio and password: $password"
@@ -144,7 +153,7 @@ if [ "$envtype" == "rstudio" ]; then
         -e USERID=$UID \
         -p $port:8787 \
         $biocdocker \
-        bash -c 'chown -R rstudio /home/rstudio; chown -R rstudio /usr/local/lib/R/host-site-library; /init'
+        bash -c '/init'
 elif [ "$envtype" == "bash" ]; then
     docker run -ti --user rstudio \
         -v $DOCKER_HOME:/home/rstudio \

--- a/bioc-run
+++ b/bioc-run
@@ -117,11 +117,16 @@ copy_config .Rprofile .gitconfig .inputrc
 
 
 if [ "$envtype" == "reset-ownership" ]; then
+    IFS=':' read USERID GROUPID <<<$(grep "^$(whoami):" /etc/passwd | cut -d':' -f3,4)
+    echo ""
+    echo "=================================================="
+    echo "Resetting ownership of '$DOCKER_HOME' and '$DOCKER_RPKGS' to '$USERID:$GROUPID'"
+    echo "=================================================="
     docker run -e PASSWORD=$password \
         -v $DOCKER_HOME:/home/rstudio \
         -v $DOCKER_RPKGS:/usr/local/lib/r/host-site-library \
-        -e USERID=$(cat /etc/passwd | grep "^$(whoami):" | awk -F':' '{print $3}') \
-        -e GROUPID=$(cat /etc/passwd | grep "^$(whoami):" | awk -F':' '{print $4}') \
+        -e USERID=$USERID \
+        -e GROUPID=$GROUPID \
         -u root \
         $biocdocker \
         bash -c 'chown -R $USERID:$GROUPID /home/rstudio /usr/local/lib/r/host-site-library'

--- a/bioc-run
+++ b/bioc-run
@@ -1,6 +1,6 @@
 #!/bin/bash
 show_help() {
-    echo "Usage: bioc-run [-v version] [-e envtype] [-p port] [-w password] [-d dockerhome] [-l] [-h]"
+    echo "Usage: bioc-run [-v version] [-e envtype] [-p port] [-w password] [-d dockerhome] [-l] [-h] [-r]"
     echo "  -v version    Specify the Bioconductor version (e.g., 'devel', 'RELEASE_X_Y', 'X.Y')."
     echo "  -e envtype    Specify the environment type ('rstudio', 'bash', or 'R'). Default is 'rstudio'."
     echo "  -p port       Specify the port number. Default is 8787."
@@ -8,6 +8,9 @@ show_help() {
     echo "  -d dockerhome Specify the Docker home directory. Default is '$HOME/dockerhome'."
     echo "  -l            List all available Bioconductor Docker versions."
     echo "  -h            Show this help message."
+    echo "  -r            Reset the ownership of '$DOCKER_HOME' and '$DOCKER_RPKGS' to '$USERID:$GROUPID'."
+    echo "                This option ensures that files in volumes are owned by the same user and group"
+    echo "                on the host system."
     echo ""
     echo "The \$DOCKER_RPKGS environment variable is optional and used to specify the R packages directory on the host machine."
     echo "If not set, the default is '\$HOME/.docker-\$version-packages'."
@@ -26,7 +29,7 @@ port=8787
 password="bioc"
 DOCKER_HOME="$HOME/dockerhome"
 
-while getopts ":v:e:p:w:d:lh" opt; do
+while getopts ":v:e:p:w:d:lhr" opt; do
     case ${opt} in
         v )
             version=$OPTARG
@@ -50,6 +53,9 @@ while getopts ":v:e:p:w:d:lh" opt; do
         h )
             show_help
             exit 0
+            ;;
+        r )
+            resetchown="true"
             ;;
         \? )
             show_help
@@ -76,8 +82,8 @@ elif [ "$envtype" == "shell" ]; then
     envtype="bash"
 fi
 
-if [[ "$envtype" != "rstudio" && "$envtype" != "bash" && "$envtype" != "R" && "$envtype" != "reset-ownership" ]]; then
-    echo "Enter either 'rstudio', 'bash', 'R', or 'reset-ownership' environment type"
+if [[ "$envtype" != "rstudio" && "$envtype" != "bash" && "$envtype" != "R" ]]; then
+    echo "Enter either 'rstudio', 'bash', or 'R' environment type"
     exit 2
 fi
 
@@ -115,8 +121,7 @@ copy_config() {
 
 copy_config .Rprofile .gitconfig .inputrc
 
-
-if [ "$envtype" == "reset-ownership" ]; then
+if [ -n "$resetchown" ]; then
     IFS=':' read USERID GROUPID <<<$(grep "^$(whoami):" /etc/passwd | cut -d':' -f3,4)
     echo ""
     echo "=================================================="

--- a/bioc-run
+++ b/bioc-run
@@ -76,8 +76,8 @@ elif [ "$envtype" == "shell" ]; then
     envtype="bash"
 fi
 
-if [[ "$envtype" != "rstudio" && "$envtype" != "bash" && "$envtype" != "R" ]]; then
-    echo "Enter either 'rstudio', 'bash', or 'R' environment type"
+if [[ "$envtype" != "rstudio" && "$envtype" != "bash" && "$envtype" != "R" && "$envtype" != "reset-ownership" ]]; then
+    echo "Enter either 'rstudio', 'bash', 'R', or 'reset-ownership' environment type"
     exit 2
 fi
 
@@ -115,6 +115,19 @@ copy_config() {
 
 copy_config .Rprofile .gitconfig .inputrc
 
+
+if [ "$envtype" == "reset-ownership" ]; then
+    docker run -e PASSWORD=$password \
+        -v $DOCKER_HOME:/home/rstudio \
+        -v $DOCKER_RPKGS:/usr/local/lib/r/host-site-library \
+        -e USERID=$(cat /etc/passwd | grep "^$(whoami):" | awk -F':' '{print $3}') \
+        -e GROUPID=$(cat /etc/passwd | grep "^$(whoami):" | awk -F':' '{print $4}') \
+        -u root \
+        $biocdocker \
+        bash -c 'chown -R $USERID:$GROUPID /home/rstudio /usr/local/lib/r/host-site-library'
+        exit
+fi
+
 echo ""
 echo "=================================================="
 echo "Installed packages will go in host directory: $DOCKER_RPKGS"
@@ -133,16 +146,7 @@ docker run --rm \
       $biocdocker \
       bash -c 'chown -R $USERID:1000 /home/rstudio /usr/local/lib/r/host-site-library'
 
-if [ "$envtype" == "reset-ownership" ]; then
-    docker run -e PASSWORD=$password \
-        -v $DOCKER_HOME:/home/rstudio \
-        -v $DOCKER_RPKGS:/usr/local/lib/r/host-site-library \
-        -e USERID=$(cat /etc/passwd | grep "^$(whoami):" | awk -F':' '{print $3}') \
-        -e GROUPID=$(cat /etc/passwd | grep "^$(whoami):" | awk -F':' '{print $4}') \
-        -u root \
-        $biocdocker \
-        bash -c 'chown -R $USERID:$GROUPID /home/rstudio /usr/local/lib/r/host-site-library'
-elif [ "$envtype" == "rstudio" ]; then
+if [ "$envtype" == "rstudio" ]; then
     echo "=================================================="
     echo "Open RStudio running Bioconductor version $version at http://localhost:$port"
     echo "Login with username: rstudio and password: $password"


### PR DESCRIPTION
Also removes the chown from rstudio startup, since now handled universally with group ownership.