### PR TITLE
Add Rscript support and non-interactive TTY detection

### DIFF
--- a/bioc-run
+++ b/bioc-run
@@ -2,7 +2,7 @@
 show_help() {
     echo "Usage: bioc-run [-v version] [-e envtype] [-p port] [-w password] [-d dockerhome] [-l] [-h] [-r] [-q] [-- args...]"
     echo "  -v version    Specify the Bioconductor version (e.g., 'devel', 'RELEASE_X_Y', 'X.Y')."
-    echo "  -e envtype    Specify the environment type ('rstudio', 'bash', or 'R'). Default is 'rstudio'."
+    echo "  -e envtype    Specify the environment type ('rstudio', 'bash', 'R', or 'Rscript'). Default is 'rstudio'."
     echo "  -p port       Specify the port number. Default is 8787."
     echo "  -w password   Specify the RStudio password. Default is 'bioc'."
     echo "  -d dockerhome Specify the Docker home directory. Default is '$HOME/dockerhome'."
@@ -15,10 +15,11 @@ show_help() {
     echo ""
     echo "Additional arguments after the options will be passed to the environment:"
     echo "  - For 'R' mode: passed as arguments to R (e.g., 'CMD build .' or '--version')"
+    echo "  - For 'Rscript' mode: passed as arguments to Rscript (e.g., 'myscript.R' or '-e \"code\"')"
     echo "  - For 'bash' mode: passed as arguments to bash (e.g., '-c \"command\"')"
     echo "  - For 'rstudio' mode: extra arguments are ignored with a warning"
     echo ""
-    echo "For 'R' and 'bash' modes, the current working directory is mounted at /workspace"
+    echo "For 'R', 'Rscript', and 'bash' modes, the current working directory is mounted at /workspace"
     echo "inside the container, allowing you to access local files directly."
     echo ""
     echo "IMPORTANT: Use '--' to stop option parsing if you need to pass arguments that conflict"
@@ -29,6 +30,8 @@ show_help() {
     echo "  bioc-run -v devel -e R CMD build myPackage/"
     echo "  bioc-run -v devel -e R --version"
     echo "  bioc-run -v devel -e R -- -e \"print('hello')\"         # Use -- to pass -e to R"
+    echo "  bioc-run -v devel -e Rscript myscript.R"
+    echo "  bioc-run -v devel -e Rscript -- -e \"print('hello')\""
     echo "  bioc-run -v devel -e bash -c 'R CMD build .'"
     echo "  bioc-run -v devel -e bash -- -c 'echo test'           # Use -- to pass -c to bash"
     echo ""
@@ -109,8 +112,8 @@ elif [ "$envtype" == "shell" ]; then
     envtype="bash"
 fi
 
-if [[ "$envtype" != "rstudio" && "$envtype" != "bash" && "$envtype" != "R" ]]; then
-    echo "Enter either 'rstudio', 'bash', or 'R' environment type"
+if [[ "$envtype" != "rstudio" && "$envtype" != "bash" && "$envtype" != "R" && "$envtype" != "Rscript" ]]; then
+    echo "Enter either 'rstudio', 'bash', 'R', or 'Rscript' environment type"
     exit 2
 fi
 
@@ -119,6 +122,13 @@ if [ "$envtype" == "rstudio" ] && [ $# -gt 0 ]; then
     if [ "$quiet" != true ]; then
         echo "Warning: $#: extra arguments provided with rstudio mode will be ignored."
     fi
+fi
+
+# Detect if running in interactive terminal
+# Use -it for interactive terminals, -i for non-interactive (CI/CD, scripts, Claude Code)
+DOCKER_IT_FLAGS="-i"
+if [ -t 0 ]; then
+    DOCKER_IT_FLAGS="-it"
 fi
 
 biocdocker=bioconductor/bioconductor_docker:"$version"
@@ -211,14 +221,14 @@ elif [ "$envtype" == "bash" ]; then
     # On Linux, run as current user to avoid permission issues with mounted workspace
     # On macOS/Windows, run as rstudio user (Docker Desktop handles user mapping)
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        docker run -ti --user $UID:$(id -g) \
+        docker run $DOCKER_IT_FLAGS --user $UID:$(id -g) \
             -v $DOCKER_HOME:/home/rstudio \
             -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
             -v "$(pwd)":/workspace \
             -w /workspace \
             $biocdocker bash "$@"
     else
-        docker run -ti --user rstudio \
+        docker run $DOCKER_IT_FLAGS --user rstudio \
             -v $DOCKER_HOME:/home/rstudio \
             -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
             -v "$(pwd)":/workspace \
@@ -229,18 +239,36 @@ elif [ "$envtype" == "R" ]; then
     # On Linux, run as current user to avoid permission issues with mounted workspace
     # On macOS/Windows, run as rstudio user (Docker Desktop handles user mapping)
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        docker run -ti --user $UID:$(id -g) \
+        docker run $DOCKER_IT_FLAGS --user $UID:$(id -g) \
             -v $DOCKER_HOME:/home/rstudio \
             -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
             -v "$(pwd)":/workspace \
             -w /workspace \
             $biocdocker R "$@"
     else
-        docker run -ti --user rstudio \
+        docker run $DOCKER_IT_FLAGS --user rstudio \
             -v $DOCKER_HOME:/home/rstudio \
             -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
             -v "$(pwd)":/workspace \
             -w /workspace \
             $biocdocker R "$@"
+    fi
+elif [ "$envtype" == "Rscript" ]; then
+    # On Linux, run as current user to avoid permission issues with mounted workspace
+    # On macOS/Windows, run as rstudio user (Docker Desktop handles user mapping)
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        docker run $DOCKER_IT_FLAGS --user $UID:$(id -g) \
+            -v $DOCKER_HOME:/home/rstudio \
+            -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
+            -v "$(pwd)":/workspace \
+            -w /workspace \
+            $biocdocker Rscript "$@"
+    else
+        docker run $DOCKER_IT_FLAGS --user rstudio \
+            -v $DOCKER_HOME:/home/rstudio \
+            -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
+            -v "$(pwd)":/workspace \
+            -w /workspace \
+            $biocdocker Rscript "$@"
     fi
 fi


### PR DESCRIPTION
## Summary

This PR adds two complementary features to bioc-run:
1. **Rscript environment type** - Support for running R scripts directly
2. **Non-interactive TTY detection** - Automatic compatibility with CI/CD, scripts, and Claude Code sessions

This is a clean version that builds on the latest devel branch without duplicate commits.

## Features

### 1. Rscript Environment Type

Adds `Rscript` as a new environment type alongside `R`, `bash`, and `rstudio`.

**Usage:**
```bash
# Run an R script file
bioc-run -v devel -e Rscript myscript.R

# Execute inline R code
bioc-run -v devel -e Rscript -- -e "print('hello')"
```

### 2. Non-Interactive TTY Detection

Automatically detects whether stdin is connected to a terminal and adjusts docker flags accordingly.

**Problem Solved:** Previously, bioc-run unconditionally used `-ti` flags, causing failures in non-interactive environments.

**Solution:**
- Detects TTY using `[ -t 0 ]` test
- Interactive terminals: Uses `-it` flags
- Non-interactive contexts: Uses `-i` flag only

## Implementation

- Added TTY detection logic
- All docker run commands use `$DOCKER_IT_FLAGS` variable
- Added Rscript environment type with workspace mounting
- Updated help, validation, and examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)