### PR TITLE
Add explicit environment file passing and remove automatic GitHub token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,17 @@ KEY=value
 ANOTHER_KEY=another_value
 ```
 
+These files are passed to Docker as env files, so they must use Docker-compatible
+`KEY=value` syntax. In particular, a general R `~/.Renviron` file is only suitable
+if it already consists of simple `KEY=value` lines; quoted values, comments,
+`export` statements, or other `.Renviron`-specific syntax may not behave as expected.
+
 **Migration Note**: Previous versions of `bioc-run` automatically copied
 `GITHUB_PAT` and `GITHUB_TOKEN` from `~/.Renviron` to the container. This
 behavior has been removed in favor of explicit control via the `-f` flag. To
-restore this functionality, use: `bioc-run -v devel -f ~/.Renviron`
+restore this functionality, either use a Docker-compatible env file containing
+those variables, or use `~/.Renviron` only if it already matches the required
+`KEY=value` format.
 
 ## Docker Containers for Bioconductor
 

--- a/README.md
+++ b/README.md
@@ -9,15 +9,17 @@ This script makes it easy to:
 
 1. Run any version of Bioconductor represented by a tag at
   <https://hub.docker.com/r/bioconductor/bioconductor_docker/tags>
-2. Run command-line `R`, `bash`, or `RStudio`
+2. Run command-line `R`, `Rscript`, `bash`, or `RStudio`
 3. Have a persistent local packages directory for every version of
   Bioconductor, and map a local directory to the home directory on the
   container (i.e., a volume mounts).
 4. Specify the port and password for `RStudio`
 5. List all available Bioconductor versions
-6. Pass additional arguments to `R` or `bash` (e.g., `R CMD build`)
-7. Automatically mount the current working directory to `/workspace` in `R` and
-  `bash` modes.
+6. Pass additional arguments to `R`, `Rscript`, or `bash` (e.g., `R CMD build`)
+7. Automatically mount the current working directory to `/workspace` in `R`,
+  `Rscript`, and `bash` modes.
+8. Pass environment variables from files (e.g., `~/.Renviron`, `~/.env`) to the
+  container
 
 ## Pre-requisites
 
@@ -46,13 +48,15 @@ From the command-line, type `bioc-run -h` to make sure it's working:
 
 ```bash
 % ./bioc-run -h
-Usage: bioc-run [-v version] [-e envtype] [-p port] [-w password] [-d dockerhome] [-s provider] [-l] [-h] [-r] [-q] [-- args...]
+Usage: bioc-run [-v version] [-e envtype] [-p port] [-w password] [-d dockerhome] [-s provider] [-f envfile] [-l] [-h] [-r] [-q] [-- args...]
   -v version    Specify the Bioconductor version (e.g., 'devel', 'RELEASE_X_Y', 'X.Y').
-  -e envtype    Specify the environment type ('rstudio', 'bash', or 'R'). Default is 'rstudio'.
+  -e envtype    Specify the environment type ('rstudio', 'bash', 'R', or 'Rscript'). Default is 'rstudio'.
   -p port       Specify the port number. Default is 8787.
   -w password   Specify the RStudio password. Default is 'bioc'.
   -d dockerhome Specify the Docker home directory. Default is '$HOME/dockerhome'.
   -s provider   Specify the container registry provider ('docker' or 'ghcr.io'). Default is 'docker'.
+  -f envfile    Pass an environment file to Docker container (can be specified multiple times).
+                Example: -f ~/.Renviron -f ~/.env
   -l            List all available Bioconductor Docker versions.
   -h            Show this help message.
   -q            Quiet mode. Suppress informational messages.
@@ -62,22 +66,26 @@ Usage: bioc-run [-v version] [-e envtype] [-p port] [-w password] [-d dockerhome
 
 Additional arguments after the options will be passed to the environment:
   - For 'R' mode: passed as arguments to R (e.g., 'CMD build .' or '--version')
+  - For 'Rscript' mode: passed as arguments to Rscript (e.g., 'myscript.R' or '-e "code"')
   - For 'bash' mode: passed as arguments to bash (e.g., '-c "command"')
   - For 'rstudio' mode: extra arguments are ignored with a warning
 
-For 'R' and 'bash' modes, the current working directory is mounted at /workspace
+For 'R', 'Rscript', and 'bash' modes, the current working directory is mounted at /workspace
 inside the container, allowing you to access local files directly.
 
 IMPORTANT: Use '--' to stop option parsing if you need to pass arguments that conflict
-with bioc-run's own options (e.g., -e, -v, -p, -w, -d, -s, -r, -h, -l).
+with bioc-run's own options (e.g., -e, -v, -p, -w, -d, -s, -f, -r, -h, -l).
 
 Examples:
   bioc-run -v devel -e R CMD build .
   bioc-run -v devel -e R CMD build myPackage/
   bioc-run -v devel -e R --version
   bioc-run -v devel -e R -- -e "print('hello')"         # Use -- to pass -e to R
+  bioc-run -v devel -e Rscript myscript.R
+  bioc-run -v devel -e Rscript -- -e "print('hello')"
   bioc-run -v devel -e bash -c 'R CMD build .'
   bioc-run -v devel -e bash -- -c 'echo test'           # Use -- to pass -c to bash
+  bioc-run -v devel -f ~/.Renviron -f ~/.env            # Pass environment files to container
 
 The $DOCKER_RPKGS environment variable is optional and used to specify the R packages directory on the host machine.
 If not set, the default is '$HOME/.docker-$version-packages'.
@@ -87,6 +95,34 @@ This allows R packages installed in the container to be persisted on the host ma
 
 Use <kbd>Ctrl</kbd> + <kbd>C</kbd> (<kbd>⌘ Command</kbd> + <kbd>C</kbd> on OSX)
 to stop the `RStudio` server.
+
+## Passing Environment Variables
+
+The `-f` flag allows you to pass environment variables from files to the Docker
+container. This is useful for providing credentials, API keys, and other
+configuration without hardcoding them.
+
+```bash
+# Pass your .Renviron file
+bioc-run -v devel -f ~/.Renviron
+
+# Pass multiple environment files
+bioc-run -v devel -f ~/.Renviron -f ~/.env
+
+# Combine with other modes
+bioc-run -v devel -e R -f ~/.Renviron CMD build .
+```
+
+The environment files should contain one variable per line in the format:
+```
+KEY=value
+ANOTHER_KEY=another_value
+```
+
+**Migration Note**: Previous versions of `bioc-run` automatically copied
+`GITHUB_PAT` and `GITHUB_TOKEN` from `~/.Renviron` to the container. This
+behavior has been removed in favor of explicit control via the `-f` flag. To
+restore this functionality, use: `bioc-run -v devel -f ~/.Renviron`
 
 ## Docker Containers for Bioconductor
 

--- a/bioc-run
+++ b/bioc-run
@@ -1,12 +1,14 @@
 #!/bin/bash
 show_help() {
-    echo "Usage: bioc-run [-v version] [-e envtype] [-p port] [-w password] [-d dockerhome] [-s provider] [-l] [-h] [-r] [-q] [-- args...]"
+    echo "Usage: bioc-run [-v version] [-e envtype] [-p port] [-w password] [-d dockerhome] [-s provider] [-f envfile] [-l] [-h] [-r] [-q] [-- args...]"
     echo "  -v version    Specify the Bioconductor version (e.g., 'devel', 'RELEASE_X_Y', 'X.Y')."
     echo "  -e envtype    Specify the environment type ('rstudio', 'bash', 'R', or 'Rscript'). Default is 'rstudio'."
     echo "  -p port       Specify the port number. Default is 8787."
     echo "  -w password   Specify the RStudio password. Default is 'bioc'."
     echo "  -d dockerhome Specify the Docker home directory. Default is '$HOME/dockerhome'."
     echo "  -s provider   Specify the container registry service provider ('docker' or 'ghcr.io'). Default is 'docker'."
+    echo "  -f envfile    Pass an environment file to Docker container (can be specified multiple times)."
+    echo "                Example: -f ~/.Renviron -f ~/.env"
     echo "  -l            List all available Bioconductor Docker versions."
     echo "  -h            Show this help message."
     echo "  -q            Quiet mode. Suppress informational messages."
@@ -24,7 +26,7 @@ show_help() {
     echo "inside the container, allowing you to access local files directly."
     echo ""
     echo "IMPORTANT: Use '--' to stop option parsing if you need to pass arguments that conflict"
-    echo "with bioc-run's own options (e.g., -e, -v, -p, -w, -d, -s, -r, -h, -l)."
+    echo "with bioc-run's own options (e.g., -e, -v, -p, -w, -d, -s, -f, -r, -h, -l)."
     echo ""
     echo "Examples:"
     echo "  bioc-run -v devel -e R CMD build ."
@@ -35,6 +37,7 @@ show_help() {
     echo "  bioc-run -v devel -e Rscript -- -e \"print('hello')\""
     echo "  bioc-run -v devel -e bash -c 'R CMD build .'"
     echo "  bioc-run -v devel -e bash -- -c 'echo test'           # Use -- to pass -c to bash"
+    echo "  bioc-run -v devel -f ~/.Renviron -f ~/.env            # Pass environment files to container"
     echo ""
     echo "The \$DOCKER_RPKGS environment variable is optional and used to specify the R packages directory on the host machine."
     echo "If not set, the default is '\$HOME/.docker-\$version-packages'."
@@ -54,8 +57,9 @@ password="bioc"
 DOCKER_HOME="$HOME/dockerhome"
 quiet=false
 provider="docker"
+env_files=()
 
-while getopts ":v:e:p:w:d:s:lhrq" opt; do
+while getopts ":v:e:p:w:d:s:f:lhrq" opt; do
     case ${opt} in
         v )
             version=$OPTARG
@@ -74,6 +78,15 @@ while getopts ":v:e:p:w:d:s:lhrq" opt; do
             ;;
         s )
             provider=$OPTARG
+	    ;;
+        f )
+            # Expand tilde to home directory
+            expanded_path="${OPTARG/#\~/$HOME}"
+            if [ ! -f "$expanded_path" ]; then
+                echo "Warning: Environment file '$OPTARG' does not exist, skipping."
+            else
+                env_files+=("$expanded_path")
+            fi
             ;;
         l )
             list_versions
@@ -98,6 +111,12 @@ done
 
 # Shift away the processed options to access remaining arguments
 shift $((OPTIND-1))
+
+# Build docker env-file flags
+ENV_FILE_FLAGS=""
+for env_file in "${env_files[@]}"; do
+    ENV_FILE_FLAGS="$ENV_FILE_FLAGS --env-file $env_file"
+done
 
 if [ -z "$version" ]; then
     echo "Error: Version is required. Use the '-v' flag to specify a version. Use the '-l' flag to list available versions or the '-h' flag for examples."
@@ -156,14 +175,7 @@ if [ ! -f "$DOCKER_HOME/.Renviron" ]; then
     echo "R_LIBS=$R_LIBS" > $DOCKER_HOME/.Renviron
 fi
 
-TOKEN_EXP='^GITHUB_\(PAT\|TOKEN\)='
-GPAT=$(grep "$TOKEN_EXP" ~/.Renviron)
-GRENV=$(grep "$TOKEN_EXP" $DOCKER_HOME/.Renviron)
-if [ ! -z "${GPAT// }" ] && [ -z "${GRENV// }" ]; then
-    echo $GPAT >> $DOCKER_HOME/.Renviron
-fi
-
-HLIBUSER=$(grep "R_LIBS_USER" ~/.Renviron)
+HLIBUSER=$(grep "R_LIBS_USER" ~/.Renviron 2>/dev/null)
 DLIBUSER=$(grep "R_LIBS_USER" $DOCKER_HOME/.Renviron 2>/dev/null)
 if [ -z "${HLIBUSER// }" ] && [ -z "${DLIBUSER// }" ]; then
     echo "R_LIBS_USER=/usr/local/lib/R/host-site-library" >> $DOCKER_HOME/.Renviron
@@ -192,6 +204,7 @@ if [ -n "$resetchown" ]; then
         -e USERID=$USERID \
         -e GROUPID=$GROUPID \
         -u root \
+        $ENV_FILE_FLAGS \
         $biocdocker \
         bash -c 'chown -R $USERID:$GROUPID /home/rstudio /usr/local/lib/R/host-site-library'
         exit
@@ -214,6 +227,7 @@ docker run --rm \
       -v $DOCKER_HOME:/home/rstudio \
       -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
       -u root \
+      $ENV_FILE_FLAGS \
       $biocdocker \
       bash -c 'chown -R $USERID:1000 /home/rstudio /usr/local/lib/R/host-site-library'
 
@@ -229,6 +243,7 @@ if [ "$envtype" == "rstudio" ]; then
         -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
         -e USERID=$UID \
         -p $port:8787 \
+        $ENV_FILE_FLAGS \
         $biocdocker \
         bash -c '/init'
 elif [ "$envtype" == "bash" ]; then
@@ -240,6 +255,7 @@ elif [ "$envtype" == "bash" ]; then
             -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
             -v "$(pwd)":/workspace \
             -w /workspace \
+            $ENV_FILE_FLAGS \
             $biocdocker bash "$@"
     else
         docker run $DOCKER_IT_FLAGS --user rstudio \
@@ -247,6 +263,7 @@ elif [ "$envtype" == "bash" ]; then
             -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
             -v "$(pwd)":/workspace \
             -w /workspace \
+            $ENV_FILE_FLAGS \
             $biocdocker bash "$@"
     fi
 elif [ "$envtype" == "R" ]; then
@@ -258,6 +275,7 @@ elif [ "$envtype" == "R" ]; then
             -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
             -v "$(pwd)":/workspace \
             -w /workspace \
+            $ENV_FILE_FLAGS \
             $biocdocker R "$@"
     else
         docker run $DOCKER_IT_FLAGS --user rstudio \
@@ -265,6 +283,7 @@ elif [ "$envtype" == "R" ]; then
             -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
             -v "$(pwd)":/workspace \
             -w /workspace \
+            $ENV_FILE_FLAGS \
             $biocdocker R "$@"
     fi
 elif [ "$envtype" == "Rscript" ]; then
@@ -276,6 +295,7 @@ elif [ "$envtype" == "Rscript" ]; then
             -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
             -v "$(pwd)":/workspace \
             -w /workspace \
+            $ENV_FILE_FLAGS \
             $biocdocker Rscript "$@"
     else
         docker run $DOCKER_IT_FLAGS --user rstudio \
@@ -283,6 +303,7 @@ elif [ "$envtype" == "Rscript" ]; then
             -v $DOCKER_RPKGS:/usr/local/lib/R/host-site-library \
             -v "$(pwd)":/workspace \
             -w /workspace \
+            $ENV_FILE_FLAGS \
             $biocdocker Rscript "$@"
     fi
 fi

--- a/bioc-run
+++ b/bioc-run
@@ -112,10 +112,10 @@ done
 # Shift away the processed options to access remaining arguments
 shift $((OPTIND-1))
 
-# Build docker env-file flags
-ENV_FILE_FLAGS=""
+# Build docker env-file flags as an array so paths with spaces remain intact
+env_file_flags=()
 for env_file in "${env_files[@]}"; do
-    ENV_FILE_FLAGS="$ENV_FILE_FLAGS --env-file $env_file"
+    env_file_flags+=(--env-file "$env_file")
 done
 
 if [ -z "$version" ]; then

--- a/bioc-run
+++ b/bioc-run
@@ -78,7 +78,7 @@ while getopts ":v:e:p:w:d:s:f:lhrq" opt; do
             ;;
         s )
             provider=$OPTARG
-	    ;;
+            ;;
         f )
             # Expand tilde to home directory
             expanded_path="${OPTARG/#\~/$HOME}"


### PR DESCRIPTION
## Summary
This PR adds a new `-f` flag to explicitly pass environment files to Docker containers and removes the automatic copying of GitHub tokens.

## Changes
- Added `-f envfile` option to pass environment files (can be used multiple times)
- Removed automatic `GITHUB_PAT`/`GITHUB_TOKEN` copying from `~/.Renviron`
- Updated README with migration guidance and wrapper script examples

## Breaking Change: Why This Is Worthwhile

### Previous Behavior (Implicit)
- Automatically scanned `~/.Renviron` for GitHub tokens
- Copied them to the container's `.Renviron` without user knowledge
- Only worked for GitHub credentials
- No user control or visibility

### New Behavior (Explicit)
Users now have complete control via the `-f` flag:

```bash
# Explicitly pass environment variables
bioc-run -v devel -f ~/.Renviron
```

### Benefits of This Breaking Change

1. **User Control**: Users explicitly choose what environment variables are shared with containers
2. **Security**: No automatic credential sharing - follows principle of least privilege
3. **Transparency**: Clear visibility of what's being passed to the container
4. **Flexibility**: Works with any environment file (`.env`, `.Renviron`, custom files), not just GitHub tokens
5. **Extensibility**: Supports multiple files and any environment variables, not limited to GitHub

### Migration Path

**Simple approach** - Add `-f` flag to existing commands:
```bash
# Old (automatic): bioc-run -v devel
# New (explicit):  bioc-run -v devel -f ~/.Renviron
```

**Convenience approach** - Create wrapper scripts for common use cases:
```bash
# Create a wrapper script at /usr/local/bin/Rdev
#!/bin/bash
exec /path/to/bioc-run -v devel -f ~/.Renviron -e R "$@"
# Then use it simply:
Rdev CMD build .
```

Users can create multiple wrapper scripts (e.g., `bioc-run-dev`, `bioc-run-prod`) that pass different environment files for different contexts, providing the convenience of the old automatic behavior while maintaining explicit control.

The minor inconvenience of adding `-f ~/.Renviron` (or creating a simple wrapper) is outweighed by the improved security model and flexibility of which environment variables to pass to the container environment.